### PR TITLE
Fix compilation error due to undeclared variable worst

### DIFF
--- a/client/src/main/java/org/evosuite/ga/metaheuristics/sibea/SIBEA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/sibea/SIBEA.java
@@ -40,6 +40,7 @@ public class SIBEA<T extends Chromosome<T>> extends GeneticAlgorithm<T> {
     protected void evolve() {
         // (environmental selection) Iterate the following three steps until the
         // size of the population does no longer exceed mu
+        List<T> = null;
         if (population.size() > Properties.POPULATION) {
             // 1. Rank the population using Pareto Dominance and determine
             // the set of individuals with the worst rank (P').
@@ -48,7 +49,7 @@ public class SIBEA<T extends Chromosome<T>> extends GeneticAlgorithm<T> {
             rankingFunction.computeRankingAssignment(population, new LinkedHashSet<FitnessFunction<T>>(fitnessFunctions));
             int fronts = rankingFunction.getNumberOfSubfronts();
             Properties.POPULATION = tmpPopulation;
-            List<T> worst = rankingFunction.getSubfront(--fronts);
+            worst = rankingFunction.getSubfront(--fronts);
 
             // while difference is larger than size of worst front, remove whole front and get a new one.
             // 2023: Could this become an infinite loop?
@@ -74,7 +75,7 @@ public class SIBEA<T extends Chromosome<T>> extends GeneticAlgorithm<T> {
                 for (int i = 0; i < difference; i++)
                     population.remove(worst.get(i));
             }
-        }
+        
         this.currentIteration++;
     }
 


### PR DESCRIPTION
Creating the container `docker build -f Dockerfile.java8 . --tag evosuite/evosuite:latest-java-8` fails due to simple syntax errors. 

Fixed them in this PR.
However, but when running `dockerizedExecution_small.sh`, the script fails in the SIBEA class because of `worst` being null is passed to `bestOf`.

See stacktrace
```
~/Projects/evosuite/ex 1.1.0-genetic_algorithm* ❯ ./dockerizedExecution_small.sh                                                                                                   * EvoSuite 1.1.0
* Going to generate test cases for class: org.sourceforge.ifx.framework.element.PassbkItemDetail
* Starting Client-0
* Properties loaded from /evosuite/evosuite-files/evosuite.properties
* Connecting to master process on port 3765
* Analyzing classpath:
* Inheritance tree loaded from evosuite-files/inheritance.xml.gz
* Finished analyzing classpath
* Generating tests for class org.sourceforge.ifx.framework.element.PassbkItemDetail
* Test criteria:
  - Branch Coverage
  - Line Coverage
  - Statement Coverage
  - Top-Level Method Coverage
* Setting up search algorithm for whole suite generation
* Total number of test goals:
  - Branch 2
  - Line 3
  - Statement 9
  - Method 2
* Using seed 1675849992730
* Starting evolution
[MASTER] 09:53:13.864 [logback-2] ERROR ClientNodeImpl - Error when generating tests for: org.sourceforge.ifx.framework.element.PassbkItemDetail with seed 1675849992730. Configuration id : null
java.lang.NullPointerException: null
	at java.util.ArrayList.<init>(ArrayList.java:178)
	at org.evosuite.ga.metaheuristics.sibea.SIBEA.bestOf(SIBEA.java:180)
	at org.evosuite.ga.metaheuristics.sibea.SIBEA.evolve(SIBEA.java:65)
	at org.evosuite.ga.metaheuristics.sibea.SIBEA.generateSolution(SIBEA.java:159)
	at org.evosuite.strategy.WholeTestSuiteStrategy.generateTests(WholeTestSuiteStrategy.java:109)
	at org.evosuite.TestSuiteGenerator.generateTests(TestSuiteGenerator.java:630)
	at org.evosuite.TestSuiteGenerator.generateTestSuite(TestSuiteGenerator.java:205)
	at org.evosuite.rmi.service.ClientNodeImpl.lambda$startNewSearch$0(ClientNodeImpl.java:150)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
* Computation finished
[MASTER] 09:53:13.971 [main] ERROR SearchStatistics - No statistics has been saved because EvoSuite failed to generate any test case
[MASTER] 09:53:14.073 [main] ERROR TestGeneration - failed to write statistics data
84_ifx-framework completed
```